### PR TITLE
Fix host discovery error handling

### DIFF
--- a/app/src/streaming/GameStreamClient.cpp
+++ b/app/src/streaming/GameStreamClient.cpp
@@ -404,6 +404,14 @@ void GameStreamClient::find_hosts(ServerCallback<std::vector<Host>>& callback) {
 
         int sock = mdns_socket_open_ipv4(nullptr);
         if (sock < 0) {
+            brls::sync([callback, generation] {
+                if (generation != findHostsGeneration.load()) {
+                    return;
+                }
+
+                callback(GSResult<std::vector<Host>>::failure(
+                        "discovery_manager/no_ip"_i18n));
+            });
             return;
         }
 
@@ -457,8 +465,6 @@ void GameStreamClient::find_hosts(ServerCallback<std::vector<Host>>& callback) {
                 if (status == GS_OK) {
                     Host host;
                     host.address = searchContext.foundHost;
-                    host.remoteAddress =
-                        GameStreamClient::external_address_for_mdns(host.address);
                     host.hostname = server_data.hostname;
                     host.mac = server_data.mac;
                     merge_discovered_host(foundHosts, host);
@@ -480,6 +486,17 @@ void GameStreamClient::find_hosts(ServerCallback<std::vector<Host>>& callback) {
             }
 
             retro_sleep(500);
+        }
+
+        if (!isCancelled() && foundHosts.empty()) {
+            brls::sync([callback, generation] {
+                if (generation != findHostsGeneration.load()) {
+                    return;
+                }
+
+                callback(GSResult<std::vector<Host>>::failure(
+                        "discovery_manager/no_host"_i18n));
+            });
         }
 
         closeSocket();


### PR DESCRIPTION
## Summary
- return a UI error if mDNS host discovery cannot open its socket
- return a no-host result when discovery finishes without finding hosts
- avoid STUN lookup while processing local mDNS discovery results

## Motivation
On Switch, the Add Host tab can crash or get stuck shortly after entering the tab while automatic host discovery is running. Local mDNS discovery should not perform a remote STUN lookup for every discovered LAN host, and discovery failures should be reported back to the UI instead of returning silently.

## Testing
- Ran git diff --check
- CMake Switch configure could not be completed locally because DEVKITPRO is not installed in this environment