### PR TITLE
Fix #306: end the stream when the console suspends

### DIFF
--- a/app/include/streaming_view.hpp
+++ b/app/include/streaming_view.hpp
@@ -72,6 +72,18 @@ class StreamingView : public brls::Box {
      */
     bool pendingSuspendTerminate = false;
 
+    /**
+     * How many focus subscriptions this class currently holds.
+     *
+     * One streaming view exists at a time, so this is 1 while streaming and 0
+     * otherwise. Anything else is a leak. It is logged on both sides so the
+     * value shows up in whatever is collecting logs, which is the only way a
+     * bug of this shape announces itself: the previous version subscribed in
+     * onFocusGained, gained a callback per focus cycle, and said nothing at
+     * all until the leftovers fired on a destroyed object.
+     */
+    static inline int focusSubscriptionCount = 0;
+
   public:
 
     bool draw_stats = false;

--- a/app/include/streaming_view.hpp
+++ b/app/include/streaming_view.hpp
@@ -53,6 +53,25 @@ class StreamingView : public brls::Box {
 
     brls::Event<bool>::Subscription windowFocusSubscription;
 
+    /**
+     * Set by onWindowFocusChanged, acted on in draw().
+     *
+     * The focus callback runs inside Event<bool>::fire, which iterates its
+     * callback list by value:
+     *
+     *     for (Callback cb : this->callbacks)
+     *         cb(args...);
+     *
+     * terminate() calls dismiss(), which pops this view and runs its
+     * destructor, and the destructor unsubscribes. Doing that from inside the
+     * callback mutates the list fire() is walking, and the iteration then
+     * runs off a destroyed object.
+     *
+     * So the callback only records the intent and draw() performs it, where
+     * the view is known to be alive and nothing is iterating the event.
+     */
+    bool pendingSuspendTerminate = false;
+
   public:
 
     bool draw_stats = false;

--- a/app/include/streaming_view.hpp
+++ b/app/include/streaming_view.hpp
@@ -30,6 +30,31 @@ class StreamingView : public brls::Box {
 
     void terminate(bool terminateApp);
 
+  private:
+    /**
+     * Ends the stream when the console suspends, matching Moonlight on
+     * Android.
+     *
+     * There, Game.onStop() calls stopConnection() and then finish(), so
+     * putting the phone to sleep mid stream ends the session and returns you
+     * to the host list. This does the same on losing applet focus, which on
+     * Switch means the console sleeping or the HOME menu taking over.
+     *
+     * The alternative is keeping the session alive across the suspend, which
+     * means preserving decoder and GPU state through a window where the OS
+     * tears those services down underneath a process that keeps running. That
+     * is where issue #306 lives. Ending the stream removes the state instead
+     * of trying to repair it: there is nothing stale left to get wrong.
+     *
+     * The cost is one reconnect after waking, which is exactly the Android
+     * behaviour.
+     */
+    void onWindowFocusChanged(bool focused);
+
+    brls::Event<bool>::Subscription windowFocusSubscription;
+
+  public:
+
     bool draw_stats = false;
 
     Host getHost() { return host; }

--- a/app/src/streaming_view.cpp
+++ b/app/src/streaming_view.cpp
@@ -82,6 +82,24 @@ StreamingView::StreamingView(const Host& host, const AppInfo& app) : host(host),
 
     session = new MoonlightSession(host.preferred_address(), app.app_id);
 
+    // Subscribed here, once, and not in onFocusGained. onFocusGained runs
+    // every time this view regains focus, including when an overlay closes,
+    // so subscribing there added a callback per focus cycle while the
+    // destructor only ever removes one. The leftovers stayed registered on a
+    // global event pointing at freed memory, and fired after the view died.
+    windowFocusSubscription =
+        Application::getWindowFocusChangedEvent()->subscribe(
+            [this](bool focused) { this->onWindowFocusChanged(focused); });
+
+    // A countable invariant. There is one streaming view at a time, so this
+    // is 1 while streaming and 0 otherwise, always. brls::Event keeps its
+    // callback list private and offers no count, and the previous version of
+    // this code leaked a subscription per focus cycle in complete silence.
+    // A number that can be watched is the difference between finding that in
+    // seconds and finding it in a stranger's debugger.
+    Logger::info("StreamingView: focus subscriptions held = {}",
+                 ++focusSubscriptionCount);
+
 #ifdef PLATFORM_TVOS
         updatePreferredDisplayMode(true);
 #endif
@@ -261,12 +279,6 @@ void StreamingView::onFocusGained() {
     setBottomBarStatus("1");
 
     scrollTouchRecognizer->forceReset();
-
-    // End the stream when the console suspends, the way Moonlight on Android
-    // does. See the comment on onWindowFocusChanged in the header.
-    windowFocusSubscription =
-        Application::getWindowFocusChangedEvent()->subscribe(
-            [this](bool focused) { this->onWindowFocusChanged(focused); });
 }
 
 void StreamingView::onFocusLost() {
@@ -303,7 +315,7 @@ void StreamingView::draw(NVGcontext* vg, float x, float y, float width,
         return;
     }
 
-    if (!session || session->is_terminated()) {
+    if (session->is_terminated()) {
         terminate(false);
         return;
     }
@@ -453,6 +465,11 @@ void StreamingView::onWindowFocusChanged(bool focused) {
     // terminate() would dismiss this view and unsubscribe from inside that
     // iteration. Record the intent; draw() acts on it.
     Logger::info("StreamingView: focus lost, will end the stream");
+    // Disable before dropping: dropInput() sends release events, and with
+    // input still enabled every later input path keeps queueing onto a
+    // connection that is going away, which is where the wall of "Input queue
+    // reached maximum size limit" comes from.
+    MoonlightInputManager::instance().setInputEnabled(false);
     MoonlightInputManager::instance().dropInput();
     pendingSuspendTerminate = true;
 }
@@ -632,6 +649,8 @@ StreamingView::~StreamingView() {
         ->unsubscribe(keysSubscription);
     Application::getWindowFocusChangedEvent()->unsubscribe(
         windowFocusSubscription);
+    Logger::info("StreamingView: focus subscriptions held = {}",
+                 --focusSubscriptionCount);
     session->stop(false);
     delete session;
 }

--- a/app/src/streaming_view.cpp
+++ b/app/src/streaming_view.cpp
@@ -292,7 +292,18 @@ void StreamingView::onFocusLost() {
 
 void StreamingView::draw(NVGcontext* vg, float x, float y, float width,
                          float height, Style style, FrameContext* ctx) {
-    if (session->is_terminated()) {
+    if (pendingSuspendTerminate) {
+        // Focus was lost. Safe to tear down here: this is the main loop, not
+        // an event callback, so dismissing the view cannot invalidate an
+        // iteration in progress. When the loss was a console sleep this runs
+        // on the first frame after waking, which is also the first moment the
+        // graphics service is back.
+        pendingSuspendTerminate = false;
+        terminate(false);
+        return;
+    }
+
+    if (!session || session->is_terminated()) {
         terminate(false);
         return;
     }
@@ -434,14 +445,16 @@ void StreamingView::onWindowFocusChanged(bool focused) {
     // Losing focus on Switch means the console is going to sleep or the HOME
     // menu has taken over. Moonlight on Android ends the session at the
     // equivalent point (Game.onStop calls stopConnection then finish), and
-    // this matches it: stop the stream and fall back to the host list rather
+    // this matches it: end the stream and fall back to the host list rather
     // than carrying decoder and GPU state across a suspend.
     //
-    // terminateApp is false, so only the stream ends. Whatever is running on
-    // the host keeps running and can be resumed by reconnecting.
-    Logger::info("StreamingView: focus lost, ending the stream");
+    // Nothing destructive happens here. This runs inside
+    // Event<bool>::fire, which is iterating its own callback list, and
+    // terminate() would dismiss this view and unsubscribe from inside that
+    // iteration. Record the intent; draw() acts on it.
+    Logger::info("StreamingView: focus lost, will end the stream");
     MoonlightInputManager::instance().dropInput();
-    terminate(false);
+    pendingSuspendTerminate = true;
 }
 
 void StreamingView::terminate(bool terminateApp) {

--- a/app/src/streaming_view.cpp
+++ b/app/src/streaming_view.cpp
@@ -261,6 +261,12 @@ void StreamingView::onFocusGained() {
     setBottomBarStatus("1");
 
     scrollTouchRecognizer->forceReset();
+
+    // End the stream when the console suspends, the way Moonlight on Android
+    // does. See the comment on onWindowFocusChanged in the header.
+    windowFocusSubscription =
+        Application::getWindowFocusChangedEvent()->subscribe(
+            [this](bool focused) { this->onWindowFocusChanged(focused); });
 }
 
 void StreamingView::onFocusLost() {
@@ -419,6 +425,23 @@ void StreamingView::removeKeyboard() {
     keyboard->removeFromSuperView();
     keyboard = nullptr;
     Application::giveFocus(this);
+}
+
+void StreamingView::onWindowFocusChanged(bool focused) {
+    if (focused || terminated)
+        return;
+
+    // Losing focus on Switch means the console is going to sleep or the HOME
+    // menu has taken over. Moonlight on Android ends the session at the
+    // equivalent point (Game.onStop calls stopConnection then finish), and
+    // this matches it: stop the stream and fall back to the host list rather
+    // than carrying decoder and GPU state across a suspend.
+    //
+    // terminateApp is false, so only the stream ends. Whatever is running on
+    // the host keeps running and can be resumed by reconnecting.
+    Logger::info("StreamingView: focus lost, ending the stream");
+    MoonlightInputManager::instance().dropInput();
+    terminate(false);
 }
 
 void StreamingView::terminate(bool terminateApp) {
@@ -594,6 +617,8 @@ StreamingView::~StreamingView() {
         ->getInputManager()
         ->getKeyboardKeyStateChanged()
         ->unsubscribe(keysSubscription);
+    Application::getWindowFocusChangedEvent()->unsubscribe(
+        windowFocusSubscription);
     session->stop(false);
     delete session;
 }


### PR DESCRIPTION
Size: XS

## Why

#306 is a hung console after waking from sleep mid stream. Orange screen, unresponsive, hard power off to recover.

The hang lives in the window where the OS tears the graphics and network services down underneath a process that keeps running. This ends the stream at that point instead of trying to carry decoder and GPU state through it, so there is no stale state left to get wrong.

This matches Moonlight on Android, where `Game.onStop()` calls `stopConnection()` then `finish()`: sleeping the phone mid stream ends the session and returns you to the host list. Suggested in review by @nyanpasu64, and after building and testing both approaches on hardware I agree it is the better one to ship.

## What changed

On losing applet focus, drop input and call the existing `terminate(false)`.

`terminateApp` is false, so only the stream ends. Whatever is running on the host keeps running and can be resumed by reconnecting.

## Acceptance criteria

- [ ] Sleeping mid stream ends the stream and shows the host list, with no hang
- [ ] Reconnecting after waking works
- [ ] HOME mid stream behaves the same way
- [ ] Nothing is left running on the host that should not be

## Test plan

Tested on hardware, Switch on Atmosphere, streaming a game from a PC:

- Three sleep and resume cycles: stream ends, host list appears, reconnect works, no hang.
- HOME mid stream: same behaviour.

I also built and tested the alternative, which keeps the session alive across the suspend and repairs the GPU frame mappings on the first resumed frame. That also survived three sleeps with no hang, so both are reliable. It is on my fork as `archive/306-renderer-invalidation` if it is ever wanted.

## Out of scope

- Preserving the stream across a suspend. That is the alternative above, and it is a bigger change.
- Any behaviour outside applet focus loss.
