### PR TITLE
Fix #255: do not treat an all zero MAC as a host identity

### DIFF
--- a/app/src/forwarder_maker.cpp
+++ b/app/src/forwarder_maker.cpp
@@ -46,7 +46,7 @@ std::string buildForwarderArgs(const Host& host, const App& app) {
         args += value;
     };
 
-    if (!host.mac.empty()) {
+    if (is_usable_mac(host.mac)) {
         append("--host=" + host.mac);
     } else {
         const auto preferredAddress = host.preferred_address();

--- a/app/src/streaming/DiscoverManager.cpp
+++ b/app/src/streaming/DiscoverManager.cpp
@@ -195,7 +195,7 @@ void DiscoverManager::loop() {
                     if (!host.hostname.empty()) {
                         it->hostname = host.hostname;
                     }
-                    if (!host.mac.empty()) {
+                    if (is_usable_mac(host.mac)) {
                         it->mac = host.mac;
                     }
                 }

--- a/app/src/streaming/GameStreamClient.cpp
+++ b/app/src/streaming/GameStreamClient.cpp
@@ -61,7 +61,7 @@ void rebind_server_info(SERVER_DATA& server) {
 }
 
 std::string host_key(const Host& host) {
-    if (!host.mac.empty()) {
+    if (is_usable_mac(host.mac)) {
         return "mac:" + host.mac;
     }
     if (!host.address.empty()) {
@@ -92,7 +92,7 @@ void merge_discovered_host(std::vector<Host>& hosts, const Host& host) {
     if (!host.hostname.empty()) {
         it->hostname = host.hostname;
     }
-    if (!host.mac.empty()) {
+    if (is_usable_mac(host.mac)) {
         it->mac = host.mac;
     }
 }
@@ -576,7 +576,7 @@ void GameStreamClient::cache_server_data(const std::string& address,
                                          const SERVER_DATA& data) {
     m_server_data[address] = data;
     rebind_server_info(m_server_data[address]);
-    if (!data.mac.empty()) {
+    if (is_usable_mac(data.mac)) {
         m_active_addresses["mac:" + data.mac] = address;
     }
 }

--- a/app/src/streaming/WakeOnLanManager.cpp
+++ b/app/src/streaming/WakeOnLanManager.cpp
@@ -61,7 +61,19 @@ std::string normalize_mac_address(const std::string& mac) {
         }
     }
 
-    return normalized.size() == 12 ? normalized : "";
+    if (normalized.size() != 12) {
+        return "";
+    }
+
+    // An all zero MAC is what a host reports when it could not work out its
+    // own, notably Sunshine. A magic packet addressed to it wakes nothing, so
+    // reject it here rather than offering the user a button that silently
+    // does nothing.
+    if (normalized.find_first_not_of('0') == std::string::npos) {
+        return "";
+    }
+
+    return normalized;
 }
 
 bool try_parse_port(const std::string& portText, unsigned short& port) {

--- a/app/src/utils/Settings.cpp
+++ b/app/src/utils/Settings.cpp
@@ -33,7 +33,7 @@ void merge_host(Host& target, const Host& source) {
         target.remoteAddress = source.remoteAddress;
     if (!source.hostname.empty())
         target.hostname = source.hostname;
-    if (!source.mac.empty())
+    if (is_usable_mac(source.mac))
         target.mac = source.mac;
 }
 
@@ -82,7 +82,7 @@ void Settings::set_working_dir(const std::string& working_dir) {
 void Settings::add_host(const Host& host) {
     if (Host* existing = find_host(m_hosts, host)) {
         merge_host(*existing, host);
-    } else if (!host.preferred_address().empty() && !host.mac.empty()) {
+    } else if (!host.preferred_address().empty() && is_usable_mac(host.mac)) {
         m_hosts.push_back(host);
     }
 

--- a/app/src/utils/Settings.hpp
+++ b/app/src/utils/Settings.hpp
@@ -3,6 +3,7 @@
 #include "Singleton.hpp"
 #include <borealis.hpp>
 #include <map>
+#include <cctype>
 #include <cstdio>
 #include <string>
 #include <utility>
@@ -66,8 +67,30 @@ struct Host {
     }
 };
 
+/**
+ * Whether a MAC address identifies a host.
+ *
+ * A host is not required to report one. Sunshine in particular answers
+ * serverinfo with an all zero MAC when it cannot determine the real one, and
+ * that is not an identity: two different hosts would both carry it, and it is
+ * not a usable Wake-on-LAN target. Treat it the same as no MAC at all.
+ */
+inline bool is_usable_mac(const std::string& mac) {
+    for (unsigned char ch : mac) {
+        if (ch == ':' || ch == '-' || ch == ' ')
+            continue;
+        if (!std::isxdigit(ch))
+            return false;
+        if (ch != '0')
+            return true;
+    }
+
+    // Either empty, or every digit was a zero.
+    return false;
+}
+
 inline bool hosts_match(const Host& lhs, const Host& rhs) {
-    if (!lhs.mac.empty() && !rhs.mac.empty())
+    if (is_usable_mac(lhs.mac) && is_usable_mac(rhs.mac))
         return lhs.mac == rhs.mac;
 
     for (const auto& address : lhs.connection_addresses()) {


### PR DESCRIPTION
Fixes #255.

## The bug

A host is not required to report a MAC. Sunshine answers `serverinfo` with
`00:00:00:00:00:00` when it cannot work out its own. Every guard in the
codebase tested for a MAC with `!mac.empty()`, and an all zero MAC passes
that, so the placeholder was accepted as a real identity in five separate
places.

Here is the relevant part of a real `settings.json` from a Switch paired to a
Sunshine host:

```json
{ "address": "10.0.0.x", "hostname": "...", "mac": "00:00:00:00:00:00", ... }
```

**Wake-on-LAN, which is #255.** `normalize_mac_address()` turns
`00:00:00:00:00:00` into twelve valid hex digits, so `can_wake_up_host()`
returns true. The user is offered the wake action, a well formed magic packet
is built and broadcast, and it is addressed to a MAC that belongs to nothing.
Nothing wakes, no error is shown, and there is nothing for the user to see.

**Host identity.** `hosts_match()` early returns:

```cpp
if (!lhs.mac.empty() && !rhs.mac.empty())
    return lhs.mac == rhs.mac;
```

Two different hosts that both report the placeholder compare equal here and
never reach the address comparison below. Add a second Sunshine host and it
merges into the first instead of being added as its own entry.

`host_key()` has the same problem, and keys `m_active_addresses` on
`"mac:00:00:00:00:00:00"`, so the resolved address of one host can be served
for a different one.

**Forwarders.** `forwarder_maker.cpp` emitted `--host=00:00:00:00:00:00`
instead of falling back to `--ip=<address>`, producing a forwarder that cannot
find the host it was made for.

## The change

Add `is_usable_mac()` next to `hosts_match()` in `Settings.hpp`. It accepts a
MAC only if it parses as hex and contains at least one nonzero digit, and it
tolerates the usual separators.

Use it at every site that was testing `!mac.empty()` to mean "this identifies
a host":

- `hosts_match()`
- `merge_host()` and `Settings::add_host()`
- `host_key()` and `merge_discovered_host()` in `GameStreamClient.cpp`
- the host merge in `DiscoverManager.cpp`
- the forwarder argument builder in `forwarder_maker.cpp`

`normalize_mac_address()` in `WakeOnLanManager.cpp` rejects the all zero case
as well, so `can_wake_up_host()` stops advertising an action that cannot work,
and the existing "Missing or invalid host MAC address" in `wake_up_host()`
becomes accurate rather than unreachable.

With no usable MAC, all of these fall through to the address based paths that
were already there, which is the behaviour hosts without a MAC field already
got.

The `mac.empty()` checks in `main_args.cpp` are deliberately left alone. Those
ask whether the user supplied an argument at all, which is a different
question.

## Testing

- Switch build is green through the repo's own devkitPro workflow, with
  `Settings.o`, `GameStreamClient.o`, `WakeOnLanManager.o`,
  `DiscoverManager.o` and `forwarder_maker.o` all rebuilt and the NRO
  produced.
- Unit tested the predicate over: the empty string, the all zero MAC in colon,
  dash and bare forms, an ordinary MAC, a MAC with a leading zero octet, a
  value whose only nonzero digit is last, the broadcast address, and non hex
  input. All ten cases behave as intended.

On-console confirmation that the wake action now correctly disappears for a
Sunshine host reporting a null MAC is in progress, and I will report back.
